### PR TITLE
sign up page

### DIFF
--- a/obj/MyFirstAzureWebApp.csproj.nuget.dgspec.json
+++ b/obj/MyFirstAzureWebApp.csproj.nuget.dgspec.json
@@ -64,7 +64,7 @@
               "privateAssets": "all"
             }
           },
-          "runtimeIdentifierGraphPath": "C:\\Program Files\\dotnet\\sdk\\8.0.300\\RuntimeIdentifierGraph.json"
+          "runtimeIdentifierGraphPath": "C:\\Program Files\\dotnet\\sdk\\8.0.303\\RuntimeIdentifierGraph.json"
         }
       }
     }

--- a/obj/project.assets.json
+++ b/obj/project.assets.json
@@ -70,7 +70,7 @@
             "privateAssets": "all"
           }
         },
-        "runtimeIdentifierGraphPath": "C:\\Program Files\\dotnet\\sdk\\8.0.300\\RuntimeIdentifierGraph.json"
+        "runtimeIdentifierGraphPath": "C:\\Program Files\\dotnet\\sdk\\8.0.303\\RuntimeIdentifierGraph.json"
       }
     }
   }

--- a/obj/project.nuget.cache
+++ b/obj/project.nuget.cache
@@ -1,6 +1,6 @@
 {
   "version": 2,
-  "dgSpecHash": "Rhhhd4+dt7Y=",
+  "dgSpecHash": "tTIavHDGNTo=",
   "success": true,
   "projectFilePath": "C:\\tmpwork\\MyFirstAzureWebApp\\MyFirstAzureWebApp.csproj",
   "expectedPackageFiles": [],


### PR DESCRIPTION
This pull request includes changes to three files related to the .NET SDK version and the NuGet package cache. The changes update the .NET SDK version from `8.0.300` to `8.0.303` in two files, and update the `dgSpecHash` in the NuGet package cache.

* [`obj/MyFirstAzureWebApp.csproj.nuget.dgspec.json`](diffhunk://#diff-af07b04af7ab6d7f4ef9e4903b306ba4139decfc1e43260334f86f5d48ed20dfL67-R67): The .NET SDK version used in the `runtimeIdentifierGraphPath` has been updated from `8.0.300` to `8.0.303`.
* [`obj/project.assets.json`](diffhunk://#diff-253d405e61d7352b97707e95e08bdce0617c35d3e1c737b5ebaa6a35acc8b316L73-R73): Similarly, the .NET SDK version used in the `runtimeIdentifierGraphPath` has been updated from `8.0.300` to `8.0.303`.
* [`obj/project.nuget.cache`](diffhunk://#diff-85979bc20677e34e0bfb3e22e1880756d57f9f5167089d9ff00ae60a23487509L3-R3): The `dgSpecHash` has been updated, which indicates a change in the NuGet package dependencies.
This pull request primarily includes updates to the .NET SDK version and a corresponding change in the `dgSpecHash` in the `project.nuget.cache` file. 

* [`obj/MyFirstAzureWebApp.csproj.nuget.dgspec.json`](diffhunk://#diff-af07b04af7ab6d7f4ef9e4903b306ba4139decfc1e43260334f86f5d48ed20dfL67-R67): The .NET SDK version in the `runtimeIdentifierGraphPath` has been updated from `8.0.300` to `8.0.303`.
* [`obj/project.assets.json`](diffhunk://#diff-253d405e61d7352b97707e95e08bdce0617c35d3e1c737b5ebaa6a35acc8b316L73-R73): Similar to the previous file, the .NET SDK version in the `runtimeIdentifierGraphPath` has been updated from `8.0.300` to `8.0.303`.
* [`obj/project.nuget.cache`](diffhunk://#diff-85979bc20677e34e0bfb3e22e1880756d57f9f5167089d9ff00ae60a23487509L3-R3): The `dgSpecHash` has been updated, likely due to the changes in the .NET SDK version.